### PR TITLE
Using get_empty_kwargs to provide custom keyword arguments (#2487).

### DIFF
--- a/nereid/routing.py
+++ b/nereid/routing.py
@@ -47,20 +47,26 @@ class Rule(routing.Rule):
         self.is_csrf_exempt = kwargs.pop('exempt_csrf', False)
         super(Rule, self).__init__(*args, **kwargs)
 
-    def empty(self):
-        """Return an unbound copy of this rule.  This can be useful if you
-        want to reuse an already bound URL for another map.
+    def get_empty_kwargs(self):
+        """
+        Provides kwargs for instantiating empty copy with empty()
 
-        Ref: https://github.com/mitsuhiko/werkzeug/pull/645
+        Use this method to provide custom keyword arguments to the subclass of
+        ``Rule`` when calling ``some_rule.empty()``.  Helpful when the subclass
+        has custom keyword arguments that are needed at instantiation.
+
+        Must return a ``dict`` that will be provided as kwargs to the new
+        instance of ``Rule``, following the initial ``self.rule`` value which
+        is always provided as the first, required positional argument.
         """
         defaults = None
         if self.defaults:
             defaults = dict(self.defaults)
-        return self.__class__(
-            self.rule, defaults, self.subdomain, self.methods,
-            self.build_only, self.endpoint, self.strict_slashes,
-            self.redirect_to, self.alias, self.host
-        )
+        return dict(defaults=defaults, subdomain=self.subdomain,
+                    methods=self.methods, build_only=self.build_only,
+                    endpoint=self.endpoint, strict_slashes=self.strict_slashes,
+                    redirect_to=self.redirect_to, alias=self.alias,
+                    host=self.host, readonly=self.readonly)
 
     @property
     def is_readonly(self):


### PR DESCRIPTION
Refs:
- https://github.com/fulfilio/nereid/issues/11
- https://github.com/mitsuhiko/werkzeug/pull/675
- https://github.com/mitsuhiko/werkzeug/pull/677